### PR TITLE
Fix: use message.source instead of message.ruleId

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ function all(tree, file, config, next) {
             if (!err && correct.length) {
                 message = toString(node) + ' > ' + correct.join(', ');
                 message = file.warn(message, node);
-                message.ruleId = 'retext-spell';
+                message.source = 'retext-spell';
             }
 
             queue--;


### PR DESCRIPTION
I noticed this when iterating through the results of my analysis.
intensify, profanities etc. all use source, so I adjusted this for the sake of consistency.
