### PR TITLE
Replace nodehun with hunspell-spellchecker

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
     "hunspell-spellchecker": "^1.0.2",
+    "lodash": "^4.14.1",
     "nlcst-is-literal": "^1.0.0",
     "nlcst-to-string": "^1.0.0",
     "unist-util-visit": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "retext"
   ],
   "dependencies": {
+    "hunspell-spellchecker": "^1.0.2",
     "nlcst-is-literal": "^1.0.0",
     "nlcst-to-string": "^1.0.0",
-    "nodehun": "^2.0.8",
     "unist-util-visit": "^1.0.0"
   },
   "files": [

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,9 @@ file](https://github.com/wooorm/vfile)s.
 
     *   `dictionary` — See above;
 
+    *   `ignore` (`array?`, default `null`)
+        - An array of words to ignore.
+
     *   `ignoreLiteral` (`boolean?`, default `true`)
         — Whether to ignore [literal words](https://github.com/wooorm/nlcst-is-literal#isliteralparent-index).
 

--- a/readme.md
+++ b/readme.md
@@ -29,9 +29,9 @@ Yields:
 
 ```txt
 <stdin>
-   1:6-1:12  warning  useles > useless, uses                                   retext-spell
-  1:13-1:20  warning  mispelt > misspelt, mi spelt, mi-spelt, misspell, spelt  retext-spell
-  1:21-1:30  warning  documeant > document                                     retext-spell
+   1:6-1:12  warning  useles is misspelled.                                    spelling
+  1:13-1:20  warning  mispelt is misspelled.                                   spelling
+  1:21-1:30  warning  documeant is misspelled.                                 spelling
 
 ⚠ 3 warnings
 ```

--- a/test.js
+++ b/test.js
@@ -29,17 +29,6 @@ function failingLoader(callback) {
     });
 }
 
-/**
- * Fixture for a loader which fails.
- */
-function failingConstructor(callback) {
-    setImmediate(function () {
-        callback(null, {
-            'dic': 'alpha'
-        });
-    });
-}
-
 /*
  * Tests.
  */
@@ -77,29 +66,6 @@ test('should fail load errors on the VFile', function (t) {
     });
 });
 
-test('should fail construct errors on the VFile', function (t) {
-    var processor = retext().use(spell, failingConstructor);
-
-    t.plan(3);
-
-    processor.process('', function (err) {
-        var failed;
-
-        t.equal(err.message, 'First argument must be a buffer');
-
-        /*
-         * Coverage: future files can fail immediatly.
-         */
-
-        processor.process('', function (err) {
-            t.equal(err.message, 'First argument must be a buffer');
-            failed = true;
-        });
-
-        t.equal(failed, true);
-    });
-});
-
 test('should warn for misspelt words', function (t) {
     t.plan(4);
 
@@ -107,7 +73,7 @@ test('should warn for misspelt words', function (t) {
         t.equal(err, null);
 
         t.deepEqual(file.messages.map(String), [
-            '1:1-1:6: color > colour, colon, col or, col-or, Colorado'
+            '1:1-1:6: color is mispelled.'
         ]);
     });
 
@@ -115,8 +81,8 @@ test('should warn for misspelt words', function (t) {
         t.equal(err, null);
 
         t.deepEqual(file.messages.map(String), [
-            '1:1-1:7: colour > color, co lour, co-lour, col our, col-our, lour',
-            '1:12-1:19: utilise > utilize'
+            '1:1-1:7: colour is mispelled.',
+            '1:12-1:19: utilise is mispelled.'
         ]);
     });
 });
@@ -130,7 +96,7 @@ test('should warn for invalid words (coverage)', function (t) {
         t.equal(err, null);
 
         t.deepEqual(file.messages.map(String), [
-            '1:1-1:6: color > colour, colon, col or, col-or, Colorado'
+            '1:1-1:6: color is mispelled.'
         ]);
 
         /*
@@ -161,7 +127,7 @@ test('...unless `ignoreLiteral` is false', function (t) {
     }).process('“color”', function (err, file) {
         t.equal(err, null);
         t.deepEqual(file.messages.map(String), [
-            '1:2-1:7: color > colour, colon, col or, col-or, Colorado'
+            '1:2-1:7: color is mispelled.'
         ]);
     });
 });


### PR DESCRIPTION
This PR replaces nodehun, which doesn't work with the latest verion of node and is [no longer maintained](https://github.com/nathanjsweet/nodehun#looking-for-maintainers), with [hunspell-spellchecker](https://github.com/GitbookIO/hunspell-spellchecker).
