### PR TITLE
Remove ending punctuation from WordNodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,13 +45,18 @@ function all(tree, file, config) {
      */
     function one(node, index, parent) {
         var isCorrect = true;
-        var word = toString(node);
 
-        if (includes(ignore, word)) {
+        if (ignoreLiteral && isLiteral(parent, index)) {
             return;
         }
 
-        if (ignoreLiteral && isLiteral(parent, index)) {
+        if (node.children[node.children.length - 1].type == 'PunctuationNode') {
+            node.children.pop();
+        }
+
+        var word = toString(node);
+
+        if (includes(ignore, word)) {
             return;
         }
 


### PR DESCRIPTION
This is a potential workaround for https://github.com/wooorm/nlcst/issues/4 but I'm almost sure that this solution is incorrect.
