### PR TITLE
Exclude non-words from spell checker

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ var spellchecker =  new Spellchecker();
 function all(tree, file, config) {
     var ignore = config.ignore;
     var ignoreLiteral = config.ignoreLiteral;
+    var ignoreDigits = config.ignoreDigits;
 
     spellchecker.use(config.dictionary);
 
@@ -47,11 +48,11 @@ function all(tree, file, config) {
         var isCorrect = true;
         var word = toString(node);
 
-        if (includes(ignore, word)) {
+        if (ignoreLiteral && isLiteral(parent, index)) {
             return;
         }
 
-        if (ignoreLiteral && isLiteral(parent, index)) {
+        if (includes(ignore, word) || (ignoreDigits && /^\d+$/.test(word))) {
             return;
         }
 
@@ -81,6 +82,7 @@ function attacher(retext, options) {
     var load = options && (options.dictionary || options);
     var ignore = options && options.ignore;
     var ignoreLiteral = options && options.ignoreLiteral;
+    var ignoreDigits = options && options.ignoreDigits;
     var config = {};
     var loadError;
 
@@ -92,7 +94,12 @@ function attacher(retext, options) {
         ignoreLiteral = true;
     }
 
+    if (ignoreDigits === null || ignoreDigits === undefined) {
+        ignoreDigits = true;
+    }
+
     config.ignoreLiteral = ignoreLiteral;
+    config.ignoreDigits = ignoreDigits;
     config.ignore = ignore;
 
     /**

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,9 @@ file](https://github.com/wooorm/vfile)s.
     *   `ignoreLiteral` (`boolean?`, default `true`)
         — Whether to ignore [literal words](https://github.com/wooorm/nlcst-is-literal#isliteralparent-index).
 
+    *   `ignoreDigits` (`boolean?`, default `true`)
+        — Whether to ignore "words" that contain only digits, i.e. `123456`.
+
 ## License
 
 [MIT](LICENSE) © [Titus Wormer](http://wooorm.com)

--- a/test.js
+++ b/test.js
@@ -132,6 +132,41 @@ test('...unless `ignoreLiteral` is false', function (t) {
     });
 });
 
+test('should warn for misspelled hyphenated words', function (t) {
+    t.plan(2);
+
+    retext().use(spell, {
+        'dictionary': enGB,
+        'ignoreDigits': false
+    }).process('wrongely-spelled-word', function (err, file) {
+        t.equal(err, null);
+        t.deepEqual(file.messages.map(String), [
+            '1:1-1:22: wrongely-spelled-word is misspelled'
+        ]);
+    });
+});
+
+test('should not warn for correctly spelled hyphenated words', function (t) {
+    t.plan(2);
+
+    retext().use(spell, enGB).process('random-hyphenated-word', function (err, file) {
+        t.equal(err, null);
+        t.deepEqual(file.messages.map(String), []);
+    });
+});
+
+test('should not warn for ignored words in hyphenated words', function (t) {
+    t.plan(2);
+
+    retext().use(spell, {
+        'dictionary': enGB,
+        'ignore': ['wrongely']
+    }).process('wrongely-spelled-word', function (err, file) {
+        t.equal(err, null);
+        t.deepEqual(file.messages.map(String), []);
+    });
+});
+
 test('should ignore digits', function (t) {
     t.plan(2);
 
@@ -151,6 +186,29 @@ test('...unless `ignoreDigits` is false', function (t) {
         t.equal(err, null);
         t.deepEqual(file.messages.map(String), [
             '1:1-1:7: 123456 is misspelled'
+        ]);
+    });
+});
+
+test('should ignore digits with decimals', function (t) {
+    t.plan(2);
+
+    retext().use(spell, enGB).process('3.14', function (err, file) {
+        t.equal(err, null);
+        t.deepEqual(file.messages.map(String), []);
+    });
+});
+
+test('...unless `ignoreDigits` is false', function (t) {
+    t.plan(2);
+
+    retext().use(spell, {
+        'dictionary': enGB,
+        'ignoreDigits': false
+    }).process('3.15', function (err, file) {
+        t.equal(err, null);
+        t.deepEqual(file.messages.map(String), [
+            '1:1-1:5: 3.15 is misspelled'
         ]);
     });
 });

--- a/test.js
+++ b/test.js
@@ -132,6 +132,40 @@ test('...unless `ignoreLiteral` is false', function (t) {
     });
 });
 
+test('should ignore digits', function (t) {
+    t.plan(2);
+
+    retext().use(spell, enGB).process('123456', function (err, file) {
+        t.equal(err, null);
+        t.deepEqual(file.messages.map(String), []);
+    });
+});
+
+test('...unless `ignoreDigits` is false', function (t) {
+    t.plan(2);
+
+    retext().use(spell, {
+        'dictionary': enGB,
+        'ignoreDigits': false
+    }).process('123456', function (err, file) {
+        t.equal(err, null);
+        t.deepEqual(file.messages.map(String), [
+            '1:1-1:7: 123456 is misspelled'
+        ]);
+    });
+});
+
+test('should not ignore words that include digits', function (t) {
+    t.plan(2);
+
+    retext().use(spell, enGB).process('768x1024', function (err, file) {
+        t.equal(err, null);
+        t.deepEqual(file.messages.map(String), [
+            '1:1-1:9: 768x1024 is misspelled'
+        ]);
+    });
+});
+
 test('should `ignore`', function (t) {
     t.plan(2);
 


### PR DESCRIPTION
This fixes #5 

In addition to words in the `ignore` array, "words" that are just digits will also be excluded.
