### PR TITLE
Update lodash to fix vulnerability (fixes #18)

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var nspell = require('nspell')
 var visit = require('unist-util-visit')
 var toString = require('nlcst-to-string')
 var isLiteral = require('nlcst-is-literal')
-var includes = require('lodash.includes')
+var includes = require('lodash/includes')
 var quote = require('quotation')
 
 module.exports = spell

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "index.js"
   ],
   "dependencies": {
-    "lodash.includes": "^4.2.0",
+    "lodash": ">= 4.17.5",
     "nlcst-is-literal": "^1.0.0",
     "nlcst-to-string": "^2.0.0",
     "nspell": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "index.js"
   ],
   "dependencies": {
-    "lodash": ">= 4.17.5",
+    "lodash": "^4.17.5",
     "nlcst-is-literal": "^1.0.0",
     "nlcst-to-string": "^2.0.0",
     "nspell": "^2.0.0",


### PR DESCRIPTION
[Lodash versions prior to 4.17.5 are vulnerable to Prototype Pollution](https://www.npmjs.com/advisories/577).
This PR updates lodash to 4.17.5

`Closes GH-18`

<!--
Read the [contributing guidelines](https://github.com/retextjs/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/retextjs/.github/blob/master/support.md
https://github.com/retextjs/.github/blob/master/contributing.md
-->
