### PR TITLE
Added support for caching nspell suggestions

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,9 @@ function all(tree, file, config) {
       // Suggestions are very slow, so cache them (spelling mistakes other than
       // typos often occur multiple times).
       if (own.call(cache, word)) {
-        reason = cache[word]
+        var cachedSuggestionData = cache[word]
+        reason = cachedSuggestionData.reason
+        suggestions = cachedSuggestionData.suggestions
       } else {
         reason = quote(word, '`') + ' is misspelt'
 
@@ -171,11 +173,10 @@ function all(tree, file, config) {
           if (suggestions.length !== 0) {
             reason +=
               '; did you mean ' + quote(suggestions, '`').join(', ') + '?'
-            cache[word] = reason
           }
         }
 
-        cache[word] = reason
+        cache[word] = {reason, suggestions: suggestions || []}
       }
 
       message = file.message(

--- a/index.js
+++ b/index.js
@@ -148,15 +148,14 @@ function all(tree, file, config) {
     }
 
     if (!correct) {
+      reason = quote(word, '`') + ' is misspelt'
+
       // Suggestions are very slow, so cache them (spelling mistakes other than
       // typos often occur multiple times).
       if (own.call(cache, word)) {
-        var cachedSuggestionData = cache[word]
-        reason = cachedSuggestionData.reason
-        suggestions = cachedSuggestionData.suggestions
+        suggestions = cache[word]
+        reason = concatPrefixToSuggestions(reason, suggestions)
       } else {
-        reason = quote(word, '`') + ' is misspelt'
-
         if (config.count === config.max) {
           file.message(
             'Too many misspellings; no further spell suggestions are given',
@@ -171,12 +170,11 @@ function all(tree, file, config) {
           suggestions = checker.suggest(word)
 
           if (suggestions.length !== 0) {
-            reason +=
-              '; did you mean ' + quote(suggestions, '`').join(', ') + '?'
+            reason = concatPrefixToSuggestions(reason, suggestions)
           }
         }
 
-        cache[word] = {reason, suggestions: suggestions || []}
+        cache[word] = suggestions || []
       }
 
       message = file.message(
@@ -187,6 +185,11 @@ function all(tree, file, config) {
       message.actual = word
       message.expected = suggestions || []
     }
+  }
+
+  // Concatenate the formatted suggestions to a given prefix
+  function concatPrefixToSuggestions(prefix, suggestions) {
+    return prefix + '; did you mean ' + quote(suggestions, '`').join(', ') + '?'
   }
 
   // Check if a word is irrelevant.

--- a/test.js
+++ b/test.js
@@ -157,21 +157,6 @@ test('should cache suggestions', function (t) {
   }
 })
 
-test('should warn for invalid words (coverage)', function (t) {
-  var english = retext().use(spell, enGb)
-
-  t.plan(2)
-
-  english.process('color', function (_, file) {
-    check(t, file, ['1:1-1:6: `color` is misspelt'])
-
-    // Coverage: future files can start faster.
-    english.process('colour', function (_, file) {
-      check(t, file, [])
-    })
-  })
-})
-
 test('should support `max`, for maximum suggestions', function (t) {
   t.plan(1)
 

--- a/test.js
+++ b/test.js
@@ -120,6 +120,58 @@ test('should warn for invalid words (coverage)', function (t) {
   })
 })
 
+test('should cache suggestions', function (t) {
+  t.plan(2)
+
+  const retextSpell = retext().use(spell, enGb)
+
+  const numberOfChecks = 2
+
+  for (let i = 0; i < numberOfChecks; i += 1) {
+    retextSpell.process('color', function (_, file) {
+      t.deepEqual(
+        JSON.parse(JSON.stringify(file.messages)),
+        [
+          {
+            message:
+              '`color` is misspelt; did you mean `colon`, `colour`, `Colo`?',
+            name: '1:1-1:6',
+            reason:
+              '`color` is misspelt; did you mean `colon`, `colour`, `Colo`?',
+            line: 1,
+            column: 1,
+            location: {
+              start: {line: 1, column: 1, offset: 0},
+              end: {line: 1, column: 6, offset: 5}
+            },
+            source: 'retext-spell',
+            ruleId: 'color',
+            fatal: false,
+            actual: 'color',
+            expected: ['colon', 'colour', 'Colo']
+          }
+        ],
+        'should emit messages'
+      )
+    })
+  }
+})
+
+test('should warn for invalid words (coverage)', function (t) {
+  var english = retext().use(spell, enGb)
+
+  t.plan(2)
+
+  english.process('color', function (_, file) {
+    check(t, file, ['1:1-1:6: `color` is misspelt'])
+
+    // Coverage: future files can start faster.
+    english.process('colour', function (_, file) {
+      check(t, file, [])
+    })
+  })
+})
+
 test('should support `max`, for maximum suggestions', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/retextjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/retextjs/.github/blob/main/support.md
https://github.com/retextjs/.github/blob/main/contributing.md
-->
- Adds suggestion caching for issue https://github.com/retextjs/retext-spell/issues/21
- Now caching the reason and nspell suggestions so that a cached message always has suggestions in its `expected` array, previously a cached message would return an empty `expected` array.
