### PR TITLE
Add support for ignoring times (`12:34`) `ignoreDigits` is on

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@
  *   Whether to ignore literal words.
  * @property {boolean} [ignoreDigits=true]
  *   Whether to ignore “words” that contain only digits, such as `123456`.
+ * @property {boolean} [ignoreAnyDigits=false]
+ *   Whether to ignore “words” that contain *any* digits, such as `2:41pm` or `A11y`.
  * @property {boolean} [normalizeApostrophes=true]
  *   Deal with apostrophes.
  *   Whether to swap smart apostrophes (`’`) with straight apostrophes (`'`)
@@ -32,6 +34,7 @@
  * @property {Array<string>} ignore
  * @property {boolean} ignoreLiteral
  * @property {boolean} ignoreDigits
+ * @property {boolean} ignoreAnyDigits
  * @property {boolean} normalizeApostrophes
  * @property {any} checker
  * @property {Record<string, Array<string>>} cache
@@ -69,6 +72,7 @@ export default function retextSpell(options = {}) {
     max,
     ignoreLiteral,
     ignoreDigits,
+    ignoreAnyDigits,
     normalizeApostrophes,
     personal
   } = options
@@ -89,6 +93,10 @@ export default function retextSpell(options = {}) {
         : ignoreLiteral,
     ignoreDigits:
       ignoreDigits === null || ignoreDigits === undefined ? true : ignoreDigits,
+    ignoreAnyDigits:
+      ignoreAnyDigits === null || ignoreAnyDigits === undefined
+        ? false
+        : ignoreAnyDigits,
     normalizeApostrophes:
       normalizeApostrophes === null || normalizeApostrophes === undefined
         ? true
@@ -162,6 +170,7 @@ function all(tree, file, config) {
     ignore,
     ignoreLiteral,
     ignoreDigits,
+    ignoreAnyDigits,
     normalizeApostrophes,
     // To do: nspell.
     // type-coverage:ignore-next-line
@@ -286,6 +295,10 @@ function all(tree, file, config) {
    * @returns {boolean}
    */
   function irrelevant(word) {
-    return ignore.includes(word) || (ignoreDigits && /^\d+$/.test(word))
+    return (
+      ignore.includes(word) ||
+      (ignoreDigits && /^\d+$/.test(word)) ||
+      (ignoreAnyDigits && /\d/.test(word))
+    )
   }
 }

--- a/index.js
+++ b/index.js
@@ -16,9 +16,7 @@
  * @property {boolean} [ignoreLiteral=true]
  *   Whether to ignore literal words.
  * @property {boolean} [ignoreDigits=true]
- *   Whether to ignore “words” that contain only digits, such as `123456`.
- * @property {boolean} [ignoreAnyDigits=false]
- *   Whether to ignore “words” that contain *any* digits, such as `2:41pm` or `A11y`.
+ *   Whether to ignore “words” that contain only digits or are times, such as `123456` or `2:41pm`.
  * @property {boolean} [normalizeApostrophes=true]
  *   Deal with apostrophes.
  *   Whether to swap smart apostrophes (`’`) with straight apostrophes (`'`)
@@ -34,7 +32,6 @@
  * @property {Array<string>} ignore
  * @property {boolean} ignoreLiteral
  * @property {boolean} ignoreDigits
- * @property {boolean} ignoreAnyDigits
  * @property {boolean} normalizeApostrophes
  * @property {any} checker
  * @property {Record<string, Array<string>>} cache
@@ -72,7 +69,6 @@ export default function retextSpell(options = {}) {
     max,
     ignoreLiteral,
     ignoreDigits,
-    ignoreAnyDigits,
     normalizeApostrophes,
     personal
   } = options
@@ -93,10 +89,6 @@ export default function retextSpell(options = {}) {
         : ignoreLiteral,
     ignoreDigits:
       ignoreDigits === null || ignoreDigits === undefined ? true : ignoreDigits,
-    ignoreAnyDigits:
-      ignoreAnyDigits === null || ignoreAnyDigits === undefined
-        ? false
-        : ignoreAnyDigits,
     normalizeApostrophes:
       normalizeApostrophes === null || normalizeApostrophes === undefined
         ? true
@@ -170,7 +162,6 @@ function all(tree, file, config) {
     ignore,
     ignoreLiteral,
     ignoreDigits,
-    ignoreAnyDigits,
     normalizeApostrophes,
     // To do: nspell.
     // type-coverage:ignore-next-line
@@ -298,7 +289,7 @@ function all(tree, file, config) {
     return (
       ignore.includes(word) ||
       (ignoreDigits && /^\d+$/.test(word)) ||
-      (ignoreAnyDigits && /\d/.test(word))
+      (ignoreDigits && /^\d{1,2}:\d{2}(?:[ap]\.?m)?$/i.test(word))
     )
   }
 }

--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ function all(tree, file, config) {
     return (
       ignore.includes(word) ||
       (ignoreDigits && /^\d+$/.test(word)) ||
-      (ignoreDigits && /^\d{1,2}:\d{2}(?:[ap]\.?m)?$/i.test(word))
+      (ignoreDigits && /^\d{1,2}:\d{2}(?:[ap]\.?m\.?)?$/i.test(word))
     )
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -109,13 +109,8 @@ Whether to ignore [literal words][literal] (`boolean?`, default `true`).
 
 ###### `options.ignoreDigits`
 
-Whether to ignore “words” that contain only digits, such as `123456`
-(`boolean?`, default `true`).
-
-###### `options.ignoreAnyDigits`
-
-Whether to ignore “words” that contain *any* digits, such as `2:41pm` or `A11y`.
-(`boolean?`, default `false`).
+Whether to ignore “words” that contain only digits or times, such as
+`123456` or `2:41pm` (`boolean?`, default `true`).
 
 ###### `options.normalizeApostrophes`
 

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,10 @@ Whether to ignore [literal words][literal] (`boolean?`, default `true`).
 
 Whether to ignore “words” that contain only digits, such as `123456`
 (`boolean?`, default `true`).
+###### `options.ignoreAnyDigits`
+
+Whether to ignore “words” that contain *any* digits, such as `2:41pm` or `A11y`.
+(`boolean?`, default `false`).
 
 ###### `options.normalizeApostrophes`
 

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ Whether to ignore [literal words][literal] (`boolean?`, default `true`).
 
 Whether to ignore “words” that contain only digits, such as `123456`
 (`boolean?`, default `true`).
+
 ###### `options.ignoreAnyDigits`
 
 Whether to ignore “words” that contain *any* digits, such as `2:41pm` or `A11y`.

--- a/test.js
+++ b/test.js
@@ -223,15 +223,12 @@ test('should ignore digits', (t) => {
     }, t.ifErr)
 })
 
-test('should ignore words that contain any digits', (t) => {
+test('should ignore times', (t) => {
   t.plan(1)
 
   retext()
-    .use(retextSpell, {
-      dictionary: enGb,
-      ignoreAnyDigits: true
-    })
-    .process('2:41pm is a gr8 time for A11y enthusiasts.')
+    .use(retextSpell, enGb)
+    .process('2:41pm')
     .then((file) => {
       check(t, file, [])
     }, t.ifErr)
@@ -322,17 +319,6 @@ test('should not ignore words that include digits', (t) => {
     .process('768x1024')
     .then((file) => {
       check(t, file, ['1:1-1:9: `768x1024` is misspelt'])
-    }, t.ifErr)
-})
-
-test('...unless `ignoreAnyDigits` is true', (t) => {
-  t.plan(1)
-
-  retext()
-    .use(retextSpell, {dictionary: enGb, ignoreAnyDigits: true})
-    .process('768x1024')
-    .then((file) => {
-      check(t, file, [])
     }, t.ifErr)
 })
 

--- a/test.js
+++ b/test.js
@@ -224,14 +224,21 @@ test('should ignore digits', (t) => {
 })
 
 test('should ignore times', (t) => {
-  t.plan(1)
+  t.plan(2)
 
   retext()
     .use(retextSpell, enGb)
-    .process('2:41pm')
+    .process('Let’s meet at 2:41pm.')
     .then((file) => {
       check(t, file, [])
     }, t.ifErr)
+
+  retext()
+    .use(retextSpell, enGb)
+    .process("On my way! ETA 11:50!")
+    .then((file) => {
+      check(t, file, []);
+    }, t.ifErr);
 })
 
 test('should treat smart apostrophes as straight apostrophes', (t) => {

--- a/test.js
+++ b/test.js
@@ -223,6 +223,17 @@ test('should ignore digits', (t) => {
     }, t.ifErr)
 })
 
+test('should ignore words that contain any digits', (t) => {
+  t.plan(1)
+
+  retext()
+    .use(retextSpell, enGb)
+    .process('2:41pm')
+    .then((file) => {
+      check(t, file, [])
+    }, t.ifErr)
+})
+
 test('should treat smart apostrophes as straight apostrophes', (t) => {
   t.plan(3)
 

--- a/test.js
+++ b/test.js
@@ -227,8 +227,11 @@ test('should ignore words that contain any digits', (t) => {
   t.plan(1)
 
   retext()
-    .use(retextSpell, enGb)
-    .process('2:41pm')
+    .use(retextSpell, {
+      dictionary: enGb,
+      ignoreAnyDigits: true
+    })
+    .process('2:41pm is a gr8 time for A11y enthusiasts.')
     .then((file) => {
       check(t, file, [])
     }, t.ifErr)
@@ -319,6 +322,17 @@ test('should not ignore words that include digits', (t) => {
     .process('768x1024')
     .then((file) => {
       check(t, file, ['1:1-1:9: `768x1024` is misspelt'])
+    }, t.ifErr)
+})
+
+test('...unless `ignoreAnyDigits` is true', (t) => {
+  t.plan(1)
+
+  retext()
+    .use(retextSpell, {dictionary: enGb, ignoreAnyDigits: true})
+    .process('768x1024')
+    .then((file) => {
+      check(t, file, [])
     }, t.ifErr)
 })
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/retextjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/retextjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/retextjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aretextjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes
- Adds a check in the `ignoreDigits` option which will ignore any word that is a time (e.g. `2:41pm`)
- Adds a new test to ensure that times are ignored.
- Updates README to include the updated documentation for the `ignoreDigits` option.

---

Closes #24 and a step toward resolving newrelic/one-core-toolbox#38

<!--do not edit: pr-->
